### PR TITLE
Add debug apk artifact

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,3 +24,12 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+
+    - name: Assemble debug APK
+      run: ./gradlew :uhabits-android:assembleDebug
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: uhabits-debug
+        path: uhabits-android/build/outputs/apk/debug/uhabits-android-debug.apk


### PR DESCRIPTION
## Summary
- build and upload the debug APK on Android CI

## Testing
- `yamllint .github/workflows/android.yml` *(fails: too many spaces inside brackets)*
- `./gradlew :uhabits-core:test` *(fails: Could not determine the dependencies of task)*

------
https://chatgpt.com/codex/tasks/task_e_687e14bd9ca48331ac664669a6036579